### PR TITLE
ignore forbidden errors when fetching the configmap

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -24,6 +24,12 @@ func Discover(ctx context.Context, core apiv1.CoreV1Interface) (LocalRegistryHos
 
 	cfg, err := core.ConfigMaps(ConfigMapNamespace).Get(ctx, ConfigMapName, metav1.GetOptions{})
 	if err != nil {
+		if errors.IsForbidden(err) {
+			// We assume that if a cluster has restricted access to the kube-public
+			// namespace, then they likely don't have a local registry, so don't
+			// bother returning an error.
+			return result, nil
+		}
 		if errors.IsNotFound(err) {
 			return result, nil
 		}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch7698:

305184bb39a6791460969cc1edb1d7906506662c (2020-06-15 10:44:58 -0400)
ignore forbidden errors when fetching the configmap

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics