### PR TITLE
register flags to that --context works

### DIFF
--- a/cmd/kubectl-local_registry/main.go
+++ b/cmd/kubectl-local_registry/main.go
@@ -14,14 +14,20 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
+var cf *genericclioptions.ConfigFlags
+
 var rootCmd = &cobra.Command{
-	Use:   "kubectl-local-registry",
+	Use:   "local-registry [command]",
 	Short: "Kubectl plugin for interacting with local registries",
+	Example: "  kubectl local-registry get\n" +
+		"  kubectl local-registry get --context=microk8s",
 }
 
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get the local registry advertised by the cluster",
+	Example: "  kubectl local-registry get\n" +
+		"  kubectl local-registry get --context=microk8s",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		core, err := core()
@@ -45,7 +51,11 @@ var getCmd = &cobra.Command{
 }
 
 func main() {
+	cf = genericclioptions.NewConfigFlags(true)
+	cf.AddFlags(getCmd.Flags())
+
 	rootCmd.AddCommand(getCmd)
+
 	err := rootCmd.Execute()
 	if err != nil {
 		// Cobra already printed the error
@@ -54,8 +64,7 @@ func main() {
 }
 
 func core() (v1.CoreV1Interface, error) {
-	flags := genericclioptions.NewConfigFlags(true)
-	config, err := flags.ToRESTConfig()
+	config, err := cf.ToRESTConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
@@ -11,5 +12,6 @@ require (
 	k8s.io/apimachinery v0.18.4
 	k8s.io/cli-runtime v0.18.4
 	k8s.io/client-go v0.18.4
+	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 // indirect
 )


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/plugin:

cc96e1689329908eb2e1bcdeee3d285d4260d22f (2020-10-16 15:36:52 -0400)
register flags to that --context works

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics